### PR TITLE
chore: (github-actions) remove deprecated security-considerations automation

### DIFF
--- a/.github/workflows/security-considerations.properties.json
+++ b/.github/workflows/security-considerations.properties.json
@@ -1,8 +1,0 @@
-{
-  "name": "Security Considerations Workflow",
-  "description": "Checks for security considerations within a pull request description.",
-  "iconName": "cg-logo",
-  "categories": [
-      "Compliance"
-  ]
-}


### PR DESCRIPTION
Closes #6

This PR removes deprecated security-considerations automation files from this repository.

## What changed
Removed:
- .github/workflows/security-considerations.properties.json

## Why
We are cataloging and cleaning up legacy GitHub Actions and related files across the org.
This reduces supply-chain and maintenance risk.

## Related issue
- Issue: https://github.com/cloud-gov/postgres-client-boshrelease/issues/6

## Policy checks
- Date (ET): 2026-03-17
- No secrets, tokens, CUI, or PII should be added to this PR description or comments.


## Tracking
- Inventory run id: 0416f7d5-404b-4d98-88ea-e701b000d372
- Repo: cloud-gov/postgres-client-boshrelease
- Epic: cloud-gov/private#2862

## Verification
- No application/runtime code changes expected.
- CI should remain green.
